### PR TITLE
add vagrant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,36 +16,94 @@ my main focus is on support F38x and EFM8UB2 targets.  For flashing the
 bootloader initially I use a J-Link adapter (EDU or PRO is fine, also 
 J-Link OB the EFM8UB2 works).  
 
-## Requirements
+## Vagrant
 
-### gboot firmware:
-sdcc 3.6 (http://sdcc.sourceforge.net/index.php#Download)
-Segger J-Link Software (https://www.segger.com/downloads/jlink)
-libusb 1.0.21 (https://sourceforge.net/projects/libusb/files/libusb-1.0/)
+A vagrant box is provided for simplified virtual machine building and provisioning.  Vagrant uses a 
+VirtualBox virtual machine running running x64 trusty Ubuntu image.  The vagrant box that is created contains the required tools and dependencies for building both `gboot` and `gflash`
+projects.  Additionally, the vagrant box provides USB pass through and mounts the required JLink and
+gboot USB devices. 
 
-### gflash utility
-python 2.6.x (https://www.python.org/)
-IntelHex 2.1+ (https://pypi.python.org/pypi/IntelHex)
-CMake 2.8.x+ (https://cmake.org/)
+### Requirements
 
-## Building gboot
+[VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+[VirtualBox Extension Pack](http://download.virtualbox.org/virtualbox/5.2.2/Oracle_VM_VirtualBox_Extension_Pack-5.2.2-119230.vbox-extpack)
+[Vagrant](https://www.vagrantup.com/downloads.html)
+[SEGGER JLink](https://www.segger.com/downloads/jlink)
+
+The VirtualBox Extension Pack is required for USB 2.0/3.0 devices.  Close the VirtualBox application before executing the below commands.  On Windows systems, just open the *.vbox-extpack file.
+
+```shell
+wget http://download.virtualbox.org/virtualbox/5.2.2/Oracle_VM_VirtualBox_Extension_Pack-5.2.2-119230.vbox-extpack
+open -W Oracle_VM_VirtualBox_Extension_Pack-5.2.2-119230.vbox-extpack
+rm Oracle_VM_VirtualBox_Extension_Pack-5.2.2-119230.vbox-extpack
+```
+
+*NOTE: You must fill out the info form and download the latest JLink software package from SEGGER from the above link to flash the gboot bootloader project the first time.  Alternatively, you can copy the hex file and program using traditional SiLabs 8-bit USB debug adapters.
+
+### Build and Flashing It
+
+Attach the SEGGER JLink adapter to the host system before running the below commands.  
+
+Build the vagrant image.
+```
+vagrant up
+vagrant ssh
+```
+
+This will drop you in a terminal on the Ubuntu virtual machine from which you can build and flash. 
+
+To build and flash the `gboot` firmware for the F380 type with 64 kB ROM size execute the following.  See [gboot/ReadMe.txt](gboot/ReadMe.txt) for different build flags.
+```
+cd /vagrant/gboot
+make FLASH_SIZE=64 VARIANT=F38x
+```
+
+To build and flash the `gflash` utility execute the following.
+```
+cd /vagrant/gflash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+### Using It
+
+Once `gboot` has been flashed, you can 
+
+## Traditional
+
+The traditional route is provided below for building on a native OS.  The vagrant route is the recommended approach.
+
+### Requirements
+
+#### gboot firmware:
+1. [sdcc 3.6](http://sdcc.sourceforge.net/index.php#Download)
+2. [Segger J-Link Software](https://www.segger.com/downloads/jlink)
+3. [libusb 1.0.21](https://sourceforge.net/projects/libusb/files/libusb-1.0/)
+
+#### gflash utility
+1. [python 2.6.x ](https://www.python.org/)
+2. [IntelHex 2.1+](https://pypi.python.org/pypi/IntelHex)
+3. [CMake 2.8.x+](https://cmake.org/)
+
+### Building gboot
 
 Type `make FLASH_SIZE=xx VARIANT=vv`  in the `gboot` directory where
 xx is 16, 32 or 64 based on the target device and vv is one of basic, 
 dual_uart or F38x based on the chip used.
 
-## Building gflash
+### Building gflash
 
 To create the gflash binary:
 
-`mkdir build`
+```
+mkdir build
+cd build
+cmake ..
+make
+```
 
-`cd build`
-
-`cmake ..`
-
-`make`
-
-## Flashing
+### Flashing
 
 Type sudo make flash in the `gboot` directory after building.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ gboot USB devices.
 
 ### Requirements
 
-[VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-[VirtualBox Extension Pack](http://download.virtualbox.org/virtualbox/5.2.2/Oracle_VM_VirtualBox_Extension_Pack-5.2.2-119230.vbox-extpack)
-[Vagrant](https://www.vagrantup.com/downloads.html)
-[SEGGER JLink](https://www.segger.com/downloads/jlink)
+1. [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+2. [VirtualBox Extension Pack](http://download.virtualbox.org/virtualbox/5.2.2/Oracle_VM_VirtualBox_Extension_Pack-5.2.2-119230.vbox-extpack)
+3. [Vagrant](https://www.vagrantup.com/downloads.html)
+4. [SEGGER JLink Linux x64](https://www.segger.com/downloads/jlink)
 
 The VirtualBox Extension Pack is required for USB 2.0/3.0 devices.  Close the VirtualBox application before executing the below commands.  On Windows systems, just open the *.vbox-extpack file.
 
@@ -38,7 +38,7 @@ open -W Oracle_VM_VirtualBox_Extension_Pack-5.2.2-119230.vbox-extpack
 rm Oracle_VM_VirtualBox_Extension_Pack-5.2.2-119230.vbox-extpack
 ```
 
-*NOTE: You must fill out the info form and download the latest JLink software package from SEGGER from the above link to flash the gboot bootloader project the first time.  Alternatively, you can copy the hex file and program using traditional SiLabs 8-bit USB debug adapters.
+*NOTE: You must fill out the info form and download the latest JLink Linux x64 software package from SEGGER with the above link to flash the gboot bootloader project for the first time.  Alternatively, you can copy the hex file to a native OS and program using traditional SiLabs 8-bit USB debug adapters.
 
 ### Build and Flashing It
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.synced_folder "./", "/vagrant"
+
+  # enable USB in the vagrant
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--usb", "on"]
+    vb.customize ["modifyvm", :id, "--usbehci", "on"]
+  end
+
+  # add the SEGGER J-Link device
+  # add the gboot bootloader device
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["usbfilter", "add", "0", "-target", :id, "-name", "jlink", "--vendorid", "1366"]
+    vb.customize ["usbfilter", "add", "0", "-target", :id, "-name", "gboot", "--vendorid", "10c4"]
+  end
+
+  config.vm.provision "shell", path: "setup.sh"
+end

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+sudo apt-get update > /dev/null 2>&1
+sudo apt-get install -y build-essential > /dev/null 2>&1
+sudo apt-get install -y autoconf > /dev/null 2>&1
+sudo apt-get install -y automake > /dev/null 2>&1
+
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test > /dev/null 2>&1
+sudo apt-get update > /dev/null 2>&1
+sudo apt-get upgrade > /dev/null 2>&1
+sudo apt-get dist-upgrade > /dev/null 2>&1
+
+sudo dpkg --add-architecture i386 > /dev/null 2>&1
+sudo apt-get update > /dev/null 2>&1
+sudo apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386 > /dev/null 2>&1
+
+sudo apt-get install -y python-pip > /dev/null 2>&1
+sudo pip install intelhex > /dev/null 2>&1
+sudo apt-get install -y srecord > /dev/null 2>&1
+sudo apt-get install -y cmake > /dev/null 2>&1
+sudo apt-get install -y libusb-1.0-0-dev > /dev/null 2>&1
+
+wget https://versaweb.dl.sourceforge.net/project/sdcc/sdcc-linux-x86/3.6.0/sdcc-3.6.0-i386-unknown-linux2.5.tar.bz2 > /dev/null 2>&1
+tar xjf sdcc-3.6.0-i386-unknown-linux2.5.tar.bz2 > /dev/null 2>&1
+sudo cp -r sdcc-3.6.0/* /usr/local
+rm -rf sdcc-3.6.0
+rm -rf sdcc-3.6.0-i386-unknown-linux2.5.tar.bz2
+
+if [ -f /vagrant/JLink_Linux_V620i_x86_64.deb ]; then
+    sudo dpkg -i /vagrant/JLink_Linux_V620i_x86_64.deb > /dev/null 2>&1
+fi
+
+echo "All Finished!"

--- a/setup.sh
+++ b/setup.sh
@@ -26,8 +26,8 @@ sudo cp -r sdcc-3.6.0/* /usr/local
 rm -rf sdcc-3.6.0
 rm -rf sdcc-3.6.0-i386-unknown-linux2.5.tar.bz2
 
-if [ -f /vagrant/JLink_Linux_V620i_x86_64.deb ]; then
-    sudo dpkg -i /vagrant/JLink_Linux_V620i_x86_64.deb > /dev/null 2>&1
+if [ -f /vagrant/JLink_Linux_*.deb ]; then
+    sudo dpkg -i /vagrant/JLink_Linux_*.deb > /dev/null 2>&1
 fi
 
 echo "All Finished!"


### PR DESCRIPTION
add Vagrantfile for virtualbox definition and support documentation.  

Vagrant is the default method supported in future.

Tested on mac OS as the host OS with success.  Will create issue to follow-up on Linux and Windows as host OS.